### PR TITLE
DP-36166: Allow options to be passed to Dockerfile CMD

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,4 +4,4 @@ WORKDIR /usr/src/myapp
 RUN apt-get update && apt-get install -y libzip-dev zip && docker-php-ext-install zip
 COPY --from=composer /usr/bin/composer /usr/bin/composer
 RUN composer install
-CMD [ "php", "./index.php", "mass:logstream", "--logtypes=varnish-request", "--logtypes=drupal-watchdog" ]
+CMD [ "php", "./index.php", "mass:logstream", "${LOG_CMD_OPTIONS}" ]

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Fetch logs from Acquia Logstream, massage, and POST to New Relic Logs.
 - AC_API2_SECRET
 - AC_API_ENVIRONMENT_UUID (see Prod entry in self.site.yml)
 - NR_LICENSE_KEY
+- LOG_CMD_OPTIONS (e.g. `--logtypes=varnish-request --logtypes=drupal-watchdog`)
 
 #### Docker image
 See [Docker Hub](https://hub.docker.com/repository/docker/massgov/logs-acquia-to-newrelic) for a containerized version of this command.


### PR DESCRIPTION
This PR changes the Dockerfile CMD to have options set in an environment variable.